### PR TITLE
Enable CI pipeline

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -1,7 +1,7 @@
-name: CI
+name: Dev CI
 on:
   push:
-    branches:
+    branches-ignore:
       - master
 jobs:
   ci:
@@ -9,17 +9,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+    - name: Check out source code
+      uses: actions/checkout@v2.3.1
+
     - name: Set up Go 1.15
       uses: actions/setup-go@v1
       with:
         go-version: 1.15
       id: go
 
-    - name: Check out source code
-      uses: actions/checkout@v2
-
     - name: Build
-      run: make build
+      run: make clean build
 
     - name: Test
-      run: make test
+      run: make clean test

--- a/.github/workflows/master-ci.yml
+++ b/.github/workflows/master-ci.yml
@@ -1,0 +1,43 @@
+name: Master CI
+on:
+  push:
+    branches:
+      - master
+jobs:
+  ci:
+    name: Build + Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v2.3.1
+
+      - name: Set up Go 1.15
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.15
+
+      - name: Run Unit Tests
+        run: make clean test
+
+      - name: Bump and Tag Version
+        id: bumptag
+        uses: jefflinse/pr-semver-bump@v1
+        with:
+          mode: bump
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          require-release-notes: true
+          with-v: true
+
+      - name: Build and Package Artifacts
+        run: make clean package
+        env:
+          VERSION: ${{ steps.bumptag.outputs.version }}
+
+      - name: Publish Release Artifacts
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: dist/*
+          file_glob: true
+          tag: ${{ steps.bumptag.outputs.version }}
+          body: ${{ steps.bumptag.outputs.release-notes }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,18 @@
+name: Release
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, edited, reopened, synchronize, ready_for_review]
+
+jobs:
+  check-pr:
+    name: Validate Pull Request Metadata
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.1
+      - uses: jefflinse/pr-semver-bump@v1
+        name: Validate PR Metadata
+        with:
+          mode: validate
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          require-release-notes: true
+          with-v: true

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@
 
 # VSCode
 .vscode/
+
+# bin and dist dirs
+bin/
+dist/

--- a/hm/.gitignore
+++ b/hm/.gitignore
@@ -1,2 +1,0 @@
-# Build outputs
-bin/


### PR DESCRIPTION
First published release

- Enables the CI pipeline for versioning and releases
- All CLI commands are consolidated in the `hm` tool
- Basic support for the following command providers: `exec`, `lambda`, `noop`, `rest`
